### PR TITLE
Add missing build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ install mosquitto-clients
 ## Installation of the p4d daemon:
 ### install the build dependencies
 ```
-apt install build-essential pkg-config libssl-dev libjansson-dev libcurl4-openssl-dev libmariadb-dev uuid-dev
+apt install build-essential pkg-config libssl-dev libjansson-dev libcurl4-openssl-dev libmariadb-dev uuid-dev libcap-dev
 ```
 
 ### get the p4d and build it


### PR DESCRIPTION
I had to add `libcap-dev` to the installed packages in order to build, or else I got the following error:

```
g++  lib/mqtt.o lib/mqtt_c.o lib/mqtt_pal.o lib/db.o lib/dbdict.o lib/common.o lib/serial.o lib/curl.o lib/thread.o lib/json.o main.o daemon.o wsactions.o gpio.o hass.o websock.o webservice.o deconz.o p4io.o service.o specific.o -L/usr/local/lib -l:libwebsockets.a -ljansson -lssl -lz -lcap -L/usr/lib/arm-linux-gnueabihf/ -lmariadb -lrt -lcrypto -lcurl -lpthread -luuid -o p4d
/usr/bin/ld: cannot find -lcap
collect2: error: ld returned 1 exit status
make: *** [Makefile:45: p4d] Error 1
```