### PR TITLE
bugfix: home assistant unit_of_measurement has to be omitted when empty

### DIFF
--- a/HISTORY.h
+++ b/HISTORY.h
@@ -5,8 +5,8 @@
  *
  */
 
-#define _VERSION     "0.9.46"
-#define VERSION_DATE "16.03.2023"
+#define _VERSION     "0.9.46-p1"
+#define VERSION_DATE "29.06.2023"
 
 #ifdef GIT_REV
 #  define VERSION _VERSION "-GIT" GIT_REV

--- a/hass.c
+++ b/hass.c
@@ -146,7 +146,19 @@ int Daemon::mqttHaPublishSensor(SensorData& sensor, bool forceConfig)
          }
          else
          {
-            asprintf(&configJson, "{"
+            if (strlen(sensor.unit.c_str()) == 0)
+            {
+                asprintf(&configJson, "{"
+                     "\"state_topic\"         : \"%s\","
+                     "\"value_template\"      : \"{{ value_json.value }}\","
+                     "\"name\"                : \"%s %s\","
+                     "\"unique_id\"           : \"%s_" TARGET "2mqtt\""
+                     "}",
+                     sDataTopic.c_str(), sensor.title.c_str(), myTitle(), sName.c_str());
+            }
+            else
+            {
+                asprintf(&configJson, "{"
                      "\"state_topic\"         : \"%s\","
                      "\"unit_of_measurement\" : \"%s\","
                      "\"value_template\"      : \"{{ value_json.value }}\","
@@ -154,6 +166,7 @@ int Daemon::mqttHaPublishSensor(SensorData& sensor, bool forceConfig)
                      "\"unique_id\"           : \"%s_" TARGET "2mqtt\""
                      "}",
                      sDataTopic.c_str(), sensor.unit.c_str(), sensor.title.c_str(), myTitle(), sName.c_str());
+            }
          }
 
          mqttWriter->writeRetained(configTopic, configJson);


### PR DESCRIPTION
Fix for the issue reported in the holzheizer-forum.de
http://www.holzheizer-forum.de/forum/thread/59155-p4d-home-assistant-anbindung-per-mqtt-autokonfiguration-textfelder/

Short description: 
mqtt field unit_of_measurement has to be omitted when empty - otherwise home assistant reject the value.

Maybe there is a more elegant solution, but I am not a c++ developer so please bear with me ;-)